### PR TITLE
CGColorRef fix for ARC

### DIFF
--- a/Classes/DDPageControl.m
+++ b/Classes/DDPageControl.m
@@ -85,8 +85,8 @@
 	CGFloat y = CGRectGetMidY(currentBounds) - diameter / 2 ;
 	
 	// get the caller's colors it they have been set or use the defaults
-	CGColorRef onColorCG = onColor ? onColor.CGColor : [UIColor colorWithWhite: 1.0f alpha: 1.0f].CGColor ;
-	CGColorRef offColorCG = offColor ? offColor.CGColor : [UIColor colorWithWhite: 0.7f alpha: 0.5f].CGColor ;
+	UIColor *drawOnColor = onColor ? onColor : [UIColor colorWithWhite: 1.0f alpha: 1.0f];
+	UIColor *drawOffColor = offColor ? offColor : [UIColor colorWithWhite: 0.7f alpha: 0.5f];
 	
 	// actually draw the dots
 	for (int i = 0 ; i < numberOfPages ; i++)
@@ -97,12 +97,12 @@
 		{
 			if (type == DDPageControlTypeOnFullOffFull || type == DDPageControlTypeOnFullOffEmpty)
 			{
-				CGContextSetFillColorWithColor(context, onColorCG) ;
+				CGContextSetFillColorWithColor(context, drawOnColor.CGColor) ;
 				CGContextFillEllipseInRect(context, CGRectInset(dotRect, -0.5f, -0.5f)) ;
 			}
 			else
 			{
-				CGContextSetStrokeColorWithColor(context, onColorCG) ;
+				CGContextSetStrokeColorWithColor(context, drawOnColor.CGColor) ;
 				CGContextStrokeEllipseInRect(context, dotRect) ;
 			}
 		}
@@ -110,12 +110,12 @@
 		{
 			if (type == DDPageControlTypeOnEmptyOffEmpty || type == DDPageControlTypeOnFullOffEmpty)
 			{
-				CGContextSetStrokeColorWithColor(context, offColorCG) ;
+				CGContextSetStrokeColorWithColor(context, drawOffColor.CGColor) ;
 				CGContextStrokeEllipseInRect(context, dotRect) ;
 			}
 			else
 			{
-				CGContextSetFillColorWithColor(context, offColorCG) ;
+				CGContextSetFillColorWithColor(context, drawOffColor.CGColor) ;
 				CGContextFillEllipseInRect(context, CGRectInset(dotRect, -0.5f, -0.5f)) ;
 			}
 		}


### PR DESCRIPTION
Storing the CGColorRef instead of the UIColor object was causing ARC to release the UIColor object. By the time the CGColorRef was called in some cases, the color object was gone, and the app would crash. Now using the UIColor -CGColor method on-demand instead.
